### PR TITLE
Update info.plist

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1284,7 +1284,7 @@ if not find_cmd_result:
     check_output(dialogue_cmd, shell=True)
     path_list = []
 else:
-	path_list = find_cmd_result.split('\n')
+	path_list = find_cmd_result.decode("utf-8").split('\n')
 
 items = []
 for path in path_list:


### PR DESCRIPTION
Added fix for Python3 to convert from bytes to string in the file list.  This requires the language path to be changed to /usr/bin/python3, but I don't see where/if this is controlled in the workflow.